### PR TITLE
Correct the number of conv layers mentioned in the description of dlib_face_recognition_resnet_model_v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository contains trained models created by me (Davis King).  They are pr
 
 * dlib_face_recognition_resnet_model_v1.dat.bz2
   
-  This model is a ResNet network with 27 conv layers.  It's essentially a version of the ResNet-34 network from the paper Deep Residual Learning for Image Recognition by He, Zhang, Ren, and Sun with a few layers removed and the number of filters per layer reduced by half.  
+  This model is a ResNet network with 29 conv layers.  It's essentially a version of the ResNet-34 network from the paper Deep Residual Learning for Image Recognition by He, Zhang, Ren, and Sun with a few layers removed and the number of filters per layer reduced by half.  
 
   The network was trained from scratch on a dataset of about 3 million faces. This dataset is derived from a number of datasets.  The face scrub dataset (http://vintage.winklerbros.net/facescrub.html), the VGG dataset (http://www.robots.ox.ac.uk/~vgg/data/vgg_face/), and then a large number of images I scraped from the internet.  I tried as best I could to clean up the dataset by removing labeling errors, which meant filtering out a lot of stuff from VGG.  I did this by repeatedly training a face recognition CNN and then using graph clustering methods and a lot of manual review to clean up the dataset.  In the end about half the images are from VGG and face scrub.  Also, the total number of individual identities in the dataset is 7485.  I made sure to avoid overlap with identities in LFW.
 


### PR DESCRIPTION
```
anet_type net;
deserialize("dlib_face_recognition_resnet_model_v1.dat") >> net;
std::cout << net << std::endl;
```
shows that the number of 'con' layers to be 29 and not 27. 
