### PR TITLE
Replace dropout layers with multiply

### DIFF
--- a/gender-classifier/dnn_gender_classifier_v1_ex.cpp
+++ b/gender-classifier/dnn_gender_classifier_v1_ex.cpp
@@ -59,7 +59,7 @@ template <int N, typename SUBNET> using ares_ = relu<block<N, affine, 1, SUBNET>
 template <typename SUBNET> using alevel1 = avg_pool<2, 2, 2, 2, ares_<64, SUBNET>>;
 template <typename SUBNET> using alevel2 = avg_pool<2, 2, 2, 2, ares_<32, SUBNET>>;
 
-using agender_type = loss_multiclass_log<fc<2, dropout<relu<fc<16, dropout<alevel1<alevel2< input_rgb_image_sized<32>>>>>>>>>;
+using agender_type = loss_multiclass_log<fc<2, multiply<relu<fc<16, multiply<alevel1<alevel2< input_rgb_image_sized<32>>>>>>>>>;
 
 // ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
As stated in the documentation, this is the recommended procedure after training a network, because it's faster and deterministic.
I've also tested it on some data of my own, and I get small accuracy improvements using `multiply`.